### PR TITLE
Support live reloading in local docker env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./
       dockerfile: Dockerfile.dev
     volumes:
-      - .:/app
+      - .:/usr/app
     command: npm run dev
     ports:
       - '3001:3000'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint && eslint .",


### PR DESCRIPTION
This will require us to disable `--turbo` builds (temporarily?) since turbopack currently does not support wasm builds.